### PR TITLE
exclude tests from published npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+test


### PR DESCRIPTION
This reduces the package size from 14.5 MB to 9.6 KB.

Context: I was trying out https://github.com/CodeStitchOfficial/Intermediate-Website-Kit-SASS and wondering why node_modules was 162 MB. I saw this package was the second biggest (after libvps, which I presume statically links image codec C libraries) because test data is shipped in the published package.